### PR TITLE
Fix save_variable unhandled SyntaxError

### DIFF
--- a/klippy/extras/save_variables.py
+++ b/klippy/extras/save_variables.py
@@ -39,8 +39,9 @@ class SaveVariables:
         value = gcmd.get('VALUE')
         try:
             value = ast.literal_eval(value)
-        except ValueError as e:
-            raise gcmd.error("Unable to parse '%s' as a literal" % (value,))
+        except (ValueError, SyntaxError) as e:
+            raise gcmd.error("Unable to parse '%s' as a Python literal"
+                                 % (value,))
         newvars = dict(self.allVariables)
         newvars[varname] = value
         # Write file


### PR DESCRIPTION
```
SAVE_VARIABLE VARIABLE="test" VALUE="Hello World"
```
Will crash your printer with a `SyntaxError`. If you are new to klipper, "Python literal" is a better description and easier to google than just "literal", hence the error string change