### PR TITLE
Add numpy to requirements.txt

### DIFF
--- a/scripts/klippy-requirements.txt
+++ b/scripts/klippy-requirements.txt
@@ -9,3 +9,4 @@ greenlet==3.0.3 ; python_version >= '3.12'
 Jinja2==2.11.3
 python-can==3.3.4
 markupsafe==1.1.1
+numpy==2.1.2


### PR DESCRIPTION
Upon first installation, Klipper will not start without it, so we should look to add it into the requirements.txt if it's intended to stay